### PR TITLE
fix: protocol-aware error handling for extended query protocol (Jelte…

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -78,7 +78,7 @@ func ClearTextPassword(validate func(ctx context.Context, database, username, pa
 
 		if !valid {
 			authErr := pgerror.WithCode(errors.New("invalid username/password"), codes.InvalidPassword)
-			err = ErrorCode(writer, authErr)
+			err = WriteUnterminatedError(writer, authErr)
 			if err != nil {
 				return ctx, err
 			}

--- a/cache.go
+++ b/cache.go
@@ -131,7 +131,8 @@ func (cache *DefaultPortalCache) Execute(ctx context.Context, name string, limit
 		return nil
 	}
 
-	return portal.statement.fn(ctx, NewDataWriter(ctx, portal.statement.columns, portal.formats, limit, reader, writer), portal.parameters)
+	session, _ := GetSession(ctx)
+	return portal.statement.fn(ctx, NewDataWriter(ctx, session, portal.statement.columns, portal.formats, limit, reader, writer), portal.parameters)
 }
 
 func (cache *DefaultPortalCache) Close() {}

--- a/command.go
+++ b/command.go
@@ -52,14 +52,6 @@ func newErrClientCopyFailed(desc string) error {
 	return psqlerr.WithSeverity(psqlerr.WithCode(err, codes.Uncategorized), psqlerr.LevelError)
 }
 
-// ErrSkipToSync is a sentinel error returned by extended query handlers to signal
-// that an error has occurred and the command loop should discard messages until
-// the next Sync message arrives. This implements the PostgreSQL protocol requirement:
-// "When an error is detected while processing any extended-query message, the backend
-// issues ErrorResponse, then reads and discards messages until a Sync is reached,
-// then issues ReadyForQuery and returns to normal message processing."
-var ErrSkipToSync = errors.New("extended query error: skip to sync")
-
 type Session struct {
 	*Server
 	Statements StatementCache
@@ -69,6 +61,31 @@ type Session struct {
 	// pipelining
 	ParallelPipeline ParallelPipelineConfig
 	ResponseQueue    *ResponseQueue
+
+	// inExtendedQuery is true when the current message being handled is an
+	// extended query protocol message (Parse, Bind, Describe, Execute, Close,
+	// Flush, Sync). This lets Session.WriteError behave correctly for both
+	// protocols.
+	inExtendedQuery bool
+
+	// discardUntilSync is set when an error occurs during extended query
+	// processing. Per the PostgreSQL protocol, after an error the server must
+	// discard messages until it receives a Sync, then respond with
+	// ReadyForQuery.
+	discardUntilSync bool
+}
+
+// isExtendedQueryMessage returns true for message types that belong to the
+// extended query protocol and should not emit ReadyForQuery on error.
+func isExtendedQueryMessage(t types.ClientMessage) bool {
+	switch t {
+	case types.ClientParse, types.ClientBind, types.ClientDescribe,
+		types.ClientExecute, types.ClientClose,
+		types.ClientSync, types.ClientFlush:
+		return true
+	default:
+		return false
+	}
 }
 
 // consumeCommands consumes incoming commands sent over the Postgres wire connection.
@@ -87,14 +104,7 @@ func (srv *Session) consumeCommands(ctx context.Context, conn net.Conn, reader *
 	defer srv.Close()
 
 	for {
-		err := srv.consumeSingleCommand(ctx, reader, writer, conn)
-		if errors.Is(err, ErrSkipToSync) {
-			if skipErr := srv.skipToSync(ctx, reader, writer); skipErr != nil {
-				return skipErr
-			}
-			continue
-		}
-		if err != nil {
+		if err = srv.consumeSingleCommand(ctx, reader, writer, conn); err != nil {
 			return err
 		}
 	}
@@ -106,9 +116,11 @@ func (srv *Session) consumeSingleCommand(ctx context.Context, reader *buffer.Rea
 		return err
 	}
 
+	srv.inExtendedQuery = isExtendedQueryMessage(t)
+
 	// NOTE: we could recover from this scenario
 	if errors.Is(err, buffer.ErrMessageSizeExceeded) {
-		err = handleMessageSizeExceeded(reader, writer, err)
+		err = srv.handleMessageSizeExceeded(reader, writer, err)
 		if err != nil {
 			return err
 		}
@@ -146,7 +158,7 @@ func (srv *Session) consumeSingleCommand(ctx context.Context, reader *buffer.Rea
 // type. A fatal error is returned when an unexpected error is returned while
 // consuming the expected message size or when attempting to write the error
 // message back to the client.
-func handleMessageSizeExceeded(reader *buffer.Reader, writer *buffer.Writer, exceeded error) (err error) {
+func (srv *Session) handleMessageSizeExceeded(reader *buffer.Reader, writer *buffer.Writer, exceeded error) (err error) {
 	unwrapped, has := buffer.UnwrapMessageSizeExceeded(exceeded)
 	if !has {
 		return exceeded
@@ -157,7 +169,7 @@ func handleMessageSizeExceeded(reader *buffer.Reader, writer *buffer.Writer, exc
 		return err
 	}
 
-	return ErrorCode(writer, exceeded)
+	return srv.WriteError(writer, exceeded)
 }
 
 // handleCommand handles the given client message. A client message includes a
@@ -165,6 +177,13 @@ func handleMessageSizeExceeded(reader *buffer.Reader, writer *buffer.Writer, exc
 // indicates a action executed by the client.
 // https://www.postgresql.org/docs/14/protocol-message-formats.html
 func (srv *Session) handleCommand(ctx context.Context, conn net.Conn, t types.ClientMessage, reader *buffer.Reader, writer *buffer.Writer) error {
+	// Per the PostgreSQL protocol, after an error during extended query
+	// processing the server discards all messages until it receives a Sync.
+	if srv.discardUntilSync && t != types.ClientSync && t != types.ClientTerminate {
+		srv.logger.Debug("discarding message until sync", slog.String("type", t.String()))
+		return nil
+	}
+
 	switch t {
 	case types.ClientSimpleQuery:
 		return srv.handleSimpleQuery(ctx, reader, writer)
@@ -200,7 +219,7 @@ func (srv *Session) handleCommand(ctx context.Context, conn net.Conn, t types.Cl
 		// At completion of each series of extended-query messages, the frontend
 		// should issue a Sync message. This parameterless message causes the
 		// backend to close the current transaction if it's not inside a
-		// BEGIN/COMMIT transaction block (“close” meaning to commit if no
+		// BEGIN/COMMIT transaction block ("close" meaning to commit if no
 		// error, or roll back if error). Then a ReadyForQuery response is
 		// issued. The purpose of Sync is to provide a resynchronization point
 		// for error recovery. When an error is detected while processing any
@@ -248,9 +267,7 @@ func (srv *Session) handleCommand(ctx context.Context, conn net.Conn, t types.Cl
 		// https://github.com/postgres/postgres/blob/6e1dd2773eb60a6ab87b27b8d9391b756e904ac3/src/backend/tcop/postgres.c#L4295
 		return nil
 	case types.ClientClose:
-		writer.Start(types.ServerCloseComplete) //nolint:errcheck
-		writer.End()                            //nolint:errcheck
-		return nil
+		return srv.handleClose(ctx, reader, writer)
 	case types.ClientTerminate:
 		err := srv.handleConnTerminate(ctx)
 		if err != nil {
@@ -264,13 +281,13 @@ func (srv *Session) handleCommand(ctx context.Context, conn net.Conn, t types.Cl
 
 		return io.EOF
 	default:
-		return ErrorCode(writer, NewErrUnimplementedMessageType(t))
+		return srv.WriteError(writer, NewErrUnimplementedMessageType(t))
 	}
 }
 
 func (srv *Session) handleSimpleQuery(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
 	if srv.parse == nil {
-		return ErrorCode(writer, NewErrUnimplementedMessageType(types.ClientSimpleQuery))
+		return srv.WriteError(writer, NewErrUnimplementedMessageType(types.ClientSimpleQuery))
 	}
 
 	query, err := reader.GetString()
@@ -296,23 +313,23 @@ func (srv *Session) handleSimpleQuery(ctx context.Context, reader *buffer.Reader
 
 	statements, err := srv.parse(ctx, query)
 	if err != nil {
-		return ErrorCode(writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	if len(statements) == 0 {
-		return ErrorCode(writer, NewErrUndefinedStatement())
+		return srv.WriteError(writer, NewErrUndefinedStatement())
 	}
 
 	// NOTE: it is possible to send multiple statements in one simple query.
 	for index := range statements {
 		err = statements[index].columns.Define(ctx, writer, nil)
 		if err != nil {
-			return ErrorCode(writer, err)
+			return srv.WriteError(writer, err)
 		}
 
-		err = statements[index].fn(ctx, NewDataWriter(ctx, statements[index].columns, nil, NoLimit, reader, writer), nil)
+		err = statements[index].fn(ctx, NewDataWriter(ctx, srv, statements[index].columns, nil, NoLimit, reader, writer), nil)
 		if err != nil {
-			return ErrorCode(writer, err)
+			return srv.WriteError(writer, err)
 		}
 	}
 
@@ -322,7 +339,7 @@ func (srv *Session) handleSimpleQuery(ctx context.Context, reader *buffer.Reader
 func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
 	if srv.parse == nil || srv.Statements == nil {
 		err := NewErrUnimplementedMessageType(types.ClientParse)
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	name, err := reader.GetString()
@@ -360,14 +377,14 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 
 	statement, err := singleStatement(srv.parse(ctx, query))
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	srv.logger.Debug("incoming extended query", slog.String("query", query), slog.String("name", name), slog.Int("parameters", len(statement.parameters)))
 
 	err = srv.Statements.Set(ctx, name, statement)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	writer.Start(types.ServerParseComplete)
@@ -378,14 +395,14 @@ func (srv *Session) handleParse(ctx context.Context, reader *buffer.Reader, writ
 func (srv *Session) parsePipelined(ctx context.Context, writer *buffer.Writer, name, query string) error {
 	statement, err := singleStatement(srv.parse(ctx, query))
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}
 
 	srv.logger.Debug("incoming extended query", slog.String("query", query), slog.String("name", name), slog.Int("parameters", len(statement.parameters)))
 
 	err = srv.Statements.Set(ctx, name, statement)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}
 
 	srv.ResponseQueue.Enqueue(NewParseCompleteEvent())
@@ -413,11 +430,11 @@ func (srv *Session) handleDescribe(ctx context.Context, reader *buffer.Reader, w
 	case types.DescribeStatement:
 		statement, err := srv.Statements.Get(ctx, name)
 		if err != nil {
-			return srv.writeExtendedQueryError(ctx, writer, err)
+			return srv.WriteError(writer, err)
 		}
 
 		if statement == nil {
-			return srv.writeExtendedQueryError(ctx, writer, errors.New("unknown statement"))
+			return srv.WriteError(writer, errors.New("unknown statement"))
 		}
 
 		if err := srv.writeParameterDescription(writer, statement.parameters); err != nil {
@@ -428,17 +445,17 @@ func (srv *Session) handleDescribe(ctx context.Context, reader *buffer.Reader, w
 	case types.DescribePortal:
 		portal, err := srv.Portals.Get(ctx, name)
 		if err != nil {
-			return srv.writeExtendedQueryError(ctx, writer, err)
+			return srv.WriteError(writer, err)
 		}
 
 		if portal == nil {
-			return srv.writeExtendedQueryError(ctx, writer, errors.New("unknown portal"))
+			return srv.WriteError(writer, errors.New("unknown portal"))
 		}
 
 		return srv.writeColumnDescription(ctx, writer, portal.formats, portal.statement.columns)
 	}
 
-	return srv.writeExtendedQueryError(ctx, writer, fmt.Errorf("unknown describe command: %s", string(d[0])))
+	return srv.WriteError(writer, fmt.Errorf("unknown describe command: %s", string(d[0])))
 }
 
 // describePipelined handles Describe in parallel pipeline mode
@@ -447,11 +464,11 @@ func (srv *Session) describePipelined(ctx context.Context, writer *buffer.Writer
 	case types.DescribeStatement:
 		statement, err := srv.Statements.Get(ctx, name)
 		if err != nil {
-			return srv.writeExtendedQueryError(ctx, writer, err)
+			return srv.drainQueueAndWriteError(ctx, writer, err)
 		}
 
 		if statement == nil {
-			return srv.writeExtendedQueryError(ctx, writer, errors.New("unknown statement"))
+			return srv.drainQueueAndWriteError(ctx, writer, errors.New("unknown statement"))
 		}
 
 		srv.ResponseQueue.Enqueue(NewStmtDescribeEvent(statement.parameters, statement.columns))
@@ -460,18 +477,18 @@ func (srv *Session) describePipelined(ctx context.Context, writer *buffer.Writer
 	case types.DescribePortal:
 		portal, err := srv.Portals.Get(ctx, name)
 		if err != nil {
-			return srv.writeExtendedQueryError(ctx, writer, err)
+			return srv.drainQueueAndWriteError(ctx, writer, err)
 		}
 
 		if portal == nil {
-			return srv.writeExtendedQueryError(ctx, writer, errors.New("unknown portal"))
+			return srv.drainQueueAndWriteError(ctx, writer, errors.New("unknown portal"))
 		}
 
 		srv.ResponseQueue.Enqueue(NewPortalDescribeEvent(portal.statement.columns, portal.formats))
 		return nil
 	}
 
-	return srv.writeExtendedQueryError(ctx, writer, fmt.Errorf("unknown describe command: %s", string(descType)))
+	return srv.drainQueueAndWriteError(ctx, writer, fmt.Errorf("unknown describe command: %s", string(descType)))
 }
 
 // https://www.postgresql.org/docs/15/protocol-message-formats.html
@@ -526,16 +543,16 @@ func (srv *Session) handleBind(ctx context.Context, reader *buffer.Reader, write
 
 	stmt, err := srv.Statements.Get(ctx, statement)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	if stmt == nil {
-		return srv.writeExtendedQueryError(ctx, writer, NewErrUnkownStatement(statement))
+		return srv.WriteError(writer, NewErrUnkownStatement(statement))
 	}
 
 	err = srv.Portals.Bind(ctx, name, stmt, parameters, formats)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	writer.Start(types.ServerBindComplete)
@@ -546,16 +563,16 @@ func (srv *Session) handleBind(ctx context.Context, reader *buffer.Reader, write
 func (srv *Session) bindPipelined(ctx context.Context, writer *buffer.Writer, name, statement string, parameters []Parameter, formats []FormatCode) error {
 	stmt, err := srv.Statements.Get(ctx, statement)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}
 
 	if stmt == nil {
-		return srv.writeExtendedQueryError(ctx, writer, NewErrUnkownStatement(statement))
+		return srv.drainQueueAndWriteError(ctx, writer, NewErrUnkownStatement(statement))
 	}
 
 	err = srv.Portals.Bind(ctx, name, stmt, parameters, formats)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}
 
 	srv.ResponseQueue.Enqueue(NewBindCompleteEvent())
@@ -654,7 +671,7 @@ func (srv *Session) readColumnTypes(reader *buffer.Reader) ([]FormatCode, error)
 func (srv *Session) handleExecute(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
 	if srv.Statements == nil {
 		err := NewErrUnimplementedMessageType(types.ClientExecute)
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	name, err := reader.GetString()
@@ -677,21 +694,46 @@ func (srv *Session) handleExecute(ctx context.Context, reader *buffer.Reader, wr
 
 	err = srv.Portals.Execute(ctx, name, Limit(limit), reader, writer)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.WriteError(writer, err)
 	}
 
 	return nil
+}
+
+// handleClose handles the Close message (extended query protocol).
+// The Close message tells the server to close a prepared statement or portal.
+// https://www.postgresql.org/docs/current/protocol-message-formats.html
+func (srv *Session) handleClose(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
+	d, err := reader.GetBytes(1)
+	if err != nil {
+		return err
+	}
+
+	name, err := reader.GetString()
+	if err != nil {
+		return err
+	}
+
+	srv.logger.Debug("incoming close request", slog.String("type", string(d[0])), slog.String("name", name))
+
+	if srv.ParallelPipeline.Enabled {
+		srv.ResponseQueue.Enqueue(NewCloseCompleteEvent())
+		return nil
+	}
+
+	writer.Start(types.ServerCloseComplete)
+	return writer.End()
 }
 
 // executePipelined handles Execute in parallel pipeline mode
 func (srv *Session) executePipelined(ctx context.Context, writer *buffer.Writer, name string, limit uint32) error {
 	portal, err := srv.Portals.Get(ctx, name)
 	if err != nil {
-		return srv.writeExtendedQueryError(ctx, writer, err)
+		return srv.drainQueueAndWriteError(ctx, writer, err)
 	}
 
 	if portal == nil {
-		return srv.writeExtendedQueryError(ctx, writer, errors.New("unknown portal"))
+		return srv.drainQueueAndWriteError(ctx, writer, errors.New("unknown portal"))
 	}
 
 	// Create result channel and queue the event
@@ -742,11 +784,16 @@ func (srv *Session) handleSync(ctx context.Context, writer *buffer.Writer) error
 		}
 	}
 
+	// Sync always resets discardUntilSync, even if queue processing set it.
+	srv.discardUntilSync = false
+
 	// Original synchronous behavior - just return ReadyForQuery
 	return readyForQuery(writer, types.ServerIdle)
 }
 
-// processResponseQueue drains the queue and writes all events to the writer
+// processResponseQueue drains the queue and writes all events to the writer.
+// Errors from async execution are written as ErrorResponse only (no ReadyForQuery)
+// because the caller (handleSync) will send ReadyForQuery after this returns.
 func (srv *Session) processResponseQueue(ctx context.Context, writer *buffer.Writer) error {
 	events, queueErr := srv.ResponseQueue.DrainSync(ctx)
 
@@ -757,7 +804,8 @@ func (srv *Session) processResponseQueue(ctx context.Context, writer *buffer.Wri
 	}
 
 	if queueErr != nil {
-		if err := ErrorCode(writer, queueErr); err != nil {
+		// Write ErrorResponse without ReadyForQuery — handleSync sends that.
+		if err := WriteUnterminatedError(writer, queueErr); err != nil {
 			return err
 		}
 	}
@@ -792,59 +840,21 @@ func (srv *Session) drainQueueOnError(ctx context.Context, writer *buffer.Writer
 	srv.ResponseQueue.Clear()
 
 	if queueErr != nil {
-		return ErrorCode(writer, queueErr)
+		// Write ErrorResponse without ReadyForQuery — the caller handles that.
+		return WriteUnterminatedError(writer, queueErr)
 	}
 
 	return nil
 }
 
-// drainQueueAndWriteError drains the queue and returns an error code.
+// drainQueueAndWriteError drains the queue and writes an error.
 // This ensures all pending successful responses are written before reporting an error.
+// Used by pipelined handlers where the queue may have pending events.
 func (srv *Session) drainQueueAndWriteError(ctx context.Context, writer *buffer.Writer, err error) error {
 	if drainErr := srv.drainQueueOnError(ctx, writer); drainErr != nil {
 		return drainErr
 	}
-	return ErrorCode(writer, err)
-}
-
-// writeExtendedQueryError handles errors during extended query protocol processing.
-// It drains any pending successful responses, writes the ErrorResponse, and returns
-// ErrSkipToSync to signal that the command loop should discard messages until Sync.
-func (srv *Session) writeExtendedQueryError(ctx context.Context, writer *buffer.Writer, err error) error {
-	if srv.ParallelPipeline.Enabled && srv.ResponseQueue != nil {
-		if drainErr := srv.drainQueueOnError(ctx, writer); drainErr != nil {
-			return drainErr
-		}
-	}
-	if werr := writeErrorResponse(writer, err); werr != nil {
-		return werr
-	}
-	return ErrSkipToSync
-}
-
-// skipToSync reads and discards messages until a Sync message is received.
-// When Sync arrives, it clears any queue state and writes ReadyForQuery.
-// This implements the PostgreSQL protocol error recovery behavior.
-func (srv *Session) skipToSync(ctx context.Context, reader *buffer.Reader, writer *buffer.Writer) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		t, _, err := reader.ReadTypedMsg()
-		if err != nil {
-			return err
-		}
-		srv.logger.Debug("discarding message until sync", slog.String("type", t.String()))
-		if t == types.ClientSync {
-			if srv.ResponseQueue != nil {
-				srv.ResponseQueue.Clear()
-			}
-			return readyForQuery(writer, types.ServerIdle)
-		}
-	}
+	return srv.WriteError(writer, err)
 }
 
 func singleStatement(stmts PreparedStatements, err error) (*PreparedStatement, error) {
@@ -874,6 +884,10 @@ func (srv *Session) writeQueuedResponse(ctx context.Context, writer *buffer.Writ
 		writer.Start(types.ServerBindComplete)
 		return writer.End()
 
+	case ResponseCloseComplete:
+		writer.Start(types.ServerCloseComplete)
+		return writer.End()
+
 	case ResponseStmtDescribe:
 		// Statement Describe writes ParameterDescription followed by RowDescription
 		if err := srv.writeParameterDescription(writer, event.Parameters); err != nil {
@@ -893,14 +907,15 @@ func (srv *Session) writeQueuedResponse(ctx context.Context, writer *buffer.Writ
 			return errors.New("execute event has no result")
 		}
 
-		// Check for execution error
+		// Check for execution error — write ErrorResponse only, no ReadyForQuery.
+		// The caller (processResponseQueue → handleSync) sends ReadyForQuery.
 		if err := event.Result.GetError(); err != nil {
-			return ErrorCode(writer, err)
+			return WriteUnterminatedError(writer, err)
 		}
 
 		// Use DataWriter for correct encoding
 		// Note: We use NoLimit here because the result is already limited during execution
-		dataWriter := NewDataWriter(ctx, event.Result.Columns(), event.Formats, NoLimit, nil, writer)
+		dataWriter := NewDataWriter(ctx, srv, event.Result.Columns(), event.Formats, NoLimit, nil, writer)
 
 		return event.Result.Replay(ctx, dataWriter)
 

--- a/command_bind_test.go
+++ b/command_bind_test.go
@@ -36,6 +36,7 @@ func TestHandleBind_ParallelPipeline_Success(t *testing.T) {
 		Statements:       statements,
 		Portals:          &DefaultPortalCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -74,6 +75,7 @@ func TestHandleBind_ParallelPipeline_Error(t *testing.T) {
 		},
 		Portals:          &DefaultPortalCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 

--- a/command_describe_test.go
+++ b/command_describe_test.go
@@ -33,6 +33,7 @@ func TestHandleDescribe_ParallelPipeline_StatementSuccess(t *testing.T) {
 		Server:           &Server{logger: logger},
 		Statements:       statements,
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -83,6 +84,7 @@ func TestHandleDescribe_ParallelPipeline_PortalSuccess(t *testing.T) {
 		Server:           &Server{logger: logger},
 		Portals:          portals,
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -119,6 +121,7 @@ func TestHandleDescribe_ParallelPipeline_Error(t *testing.T) {
 		Server:           &Server{logger: logger},
 		Statements:       &DefaultStatementCache{statements: map[string]*Statement{"unknown_stmt": nil}},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 

--- a/command_execute_test.go
+++ b/command_execute_test.go
@@ -49,6 +49,7 @@ func TestHandleExecute_ParallelPipeline_Success(t *testing.T) {
 		Statements:       &DefaultStatementCache{},
 		Portals:          &DefaultPortalCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -156,6 +157,7 @@ func TestHandleExecute_ParallelPipeline_StatementError(t *testing.T) {
 		Statements:       &DefaultStatementCache{},
 		Portals:          portals,
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -200,6 +202,7 @@ func TestHandleExecute_ParallelPipeline_UnknownPortal(t *testing.T) {
 		Statements:       &DefaultStatementCache{},
 		Portals:          &DefaultPortalCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -215,6 +218,12 @@ func TestHandleExecute_ParallelPipeline_UnknownPortal(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, session.ResponseQueue.Len())
+	assert.True(t, session.discardUntilSync)
+
+	// Sync sends ReadyForQuery and resets discardUntilSync
+	err = session.handleSync(ctx, writer)
+	require.NoError(t, err)
+	assert.False(t, session.discardUntilSync)
 
 	responseReader := mock.NewReader(t, outBuf)
 
@@ -228,7 +237,7 @@ func TestHandleExecute_ParallelPipeline_UnknownPortal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, types.ServerErrorResponse, msgType)
 
-	// 3. Ready from ErrorCode
+	// 3. ReadyForQuery from Sync
 	msgType, _, err = responseReader.ReadTypedMsg()
 	require.NoError(t, err)
 	assert.Equal(t, types.ServerReady, msgType)
@@ -266,6 +275,7 @@ func TestHandleExecute_ParallelPipeline_AsyncPanic(t *testing.T) {
 		Statements:       &DefaultStatementCache{},
 		Portals:          portals,
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 

--- a/command_parse_test.go
+++ b/command_parse_test.go
@@ -36,6 +36,7 @@ func TestHandleParse_ParallelPipeline_Success(t *testing.T) {
 		Server:           &Server{logger: logger, parse: mockParse},
 		Statements:       &DefaultStatementCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -75,6 +76,7 @@ func TestHandleParse_ParallelPipeline_MultipleCommands(t *testing.T) {
 		Server:           &Server{logger: logger, parse: mockParse},
 		Statements:       &DefaultStatementCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 
@@ -119,6 +121,7 @@ func TestHandleParse_ParallelPipeline_Error(t *testing.T) {
 		Server:           &Server{logger: logger, parse: mockParse},
 		Statements:       &DefaultStatementCache{},
 		ParallelPipeline: ParallelPipelineConfig{Enabled: true},
+		inExtendedQuery:  true,
 		ResponseQueue:    NewResponseQueue(),
 	}
 

--- a/copy.go
+++ b/copy.go
@@ -24,9 +24,10 @@ var CopySignature = []byte("PGCOPY\n\377\r\n\000")
 // NewCopyReader creates a new copy reader that reads copy-in data from the given
 // reader and writes the data to the given writer. The columns are used to determine
 // the format of the data that is read from the reader.
-func NewCopyReader(reader *buffer.Reader, writer *buffer.Writer, columns Columns) *CopyReader {
+func NewCopyReader(session *Session, reader *buffer.Reader, writer *buffer.Writer, columns Columns) *CopyReader {
 	return &CopyReader{
 		Reader:  reader,
+		session: session,
 		writer:  writer,
 		columns: columns, // NOTE: the columns are only used to determine the format of the data that is read from the reader.
 		chunk:   make([]byte, reader.MaxMessageSize),
@@ -35,6 +36,7 @@ func NewCopyReader(reader *buffer.Reader, writer *buffer.Writer, columns Columns
 
 type CopyReader struct {
 	*buffer.Reader
+	session *Session
 	writer  *buffer.Writer
 	columns Columns
 	chunk   []byte
@@ -70,12 +72,12 @@ reader:
 			if err != nil {
 				return err
 			}
-			return ErrorCode(r.writer, newErrClientCopyFailed(desc))
+			return r.session.WriteError(r.writer, newErrClientCopyFailed(desc))
 		default:
 			// Receipt of any other non-copy message type constitutes an error that
 			// will abort the copy-in state as described above.
 			// https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY
-			return ErrorCode(r.writer, NewErrUnimplementedMessageType(typed))
+			return r.session.WriteError(r.writer, NewErrUnimplementedMessageType(typed))
 		}
 	}
 }

--- a/error.go
+++ b/error.go
@@ -25,11 +25,10 @@ const (
 	errFieldConstraintName errFieldType = 'n'
 )
 
-// writeErrorResponse writes ONLY the ErrorResponse message without ReadyForQuery.
-// This is used by extended query protocol error handling where ReadyForQuery
-// must be deferred until after discarding messages up to the next Sync.
-// https://www.postgresql.org/docs/current/static/protocol-error-fields.html
-func writeErrorResponse(writer *buffer.Writer, err error) error {
+// WriteUnterminatedError writes an ErrorResponse message to the client without
+// a trailing ReadyForQuery. Use this in contexts where no session is available
+// (e.g. authentication) or where you need to control ReadyForQuery yourself.
+func WriteUnterminatedError(writer *buffer.Writer, err error) error {
 	desc := psqlerr.Flatten(err)
 
 	writer.Start(types.ServerErrorResponse)
@@ -74,20 +73,24 @@ func writeErrorResponse(writer *buffer.Writer, err error) error {
 	return writer.End()
 }
 
-// ErrorCode writes an error message as response to a command with the given
-// severity and error message. A ready for query message is written back to the
-// client once the error has been written indicating the end of a command cycle.
-// This is used by Simple Query protocol and authentication errors.
-// https://www.postgresql.org/docs/current/static/protocol-error-fields.html
-func ErrorCode(writer *buffer.Writer, err error) error {
-	if werr := writeErrorResponse(writer, err); werr != nil {
+// WriteError on Session is protocol-aware: in extended query mode it writes
+// ErrorResponse and sets `discardUntilSync` (ReadyForQuery comes from Sync).
+// In simple query mode it writes ErrorResponse + ReadyForQuery.
+func (srv *Session) WriteError(writer *buffer.Writer, err error) error {
+	if werr := WriteUnterminatedError(writer, err); werr != nil {
 		return werr
 	}
+
+	if srv.inExtendedQuery {
+		srv.discardUntilSync = true
+		return nil
+	}
+
+	desc := psqlerr.Flatten(err)
 
 	// NOTE: we are writing a ready for query message to indicate the end of a
 	// command cycle. However, for authentication failures, we skip this
 	// because the connection will be terminated.
-	desc := psqlerr.Flatten(err)
 	if desc.Code == codes.InvalidPassword {
 		return nil
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jeroenrinzema/psql-wire/pkg/types"
 	"github.com/neilotoole/slogt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorCode(t *testing.T) {
@@ -58,47 +59,167 @@ func TestErrorCode(t *testing.T) {
 	})
 }
 
-func TestErrorCodeAuthFailure(t *testing.T) {
-	t.Run("regular error includes ready for query", func(t *testing.T) {
+func TestSessionWriteError(t *testing.T) {
+	t.Run("simple query error includes ready for query", func(t *testing.T) {
+		logger := slogt.New(t)
 		sink := bytes.NewBuffer([]byte{})
-		writer := buffer.NewWriter(slogt.New(t), sink)
+		writer := buffer.NewWriter(logger, sink)
 
-		// Regular error should include ready for query message
-		err := ErrorCode(writer, psqlerr.WithCode(errors.New("some error"), codes.Syntax))
+		session := &Session{
+			Server:     &Server{logger: logger},
+			Statements: &DefaultStatementCache{},
+			Portals:    &DefaultPortalCache{},
+		}
+
+		err := session.WriteError(writer, psqlerr.WithCode(errors.New("some error"), codes.Syntax))
 		assert.NoError(t, err)
 
-		// Check that we have both ErrorResponse and Ready messages
-		reader := buffer.NewReader(slogt.New(t), sink, buffer.DefaultBufferSize)
+		reader := buffer.NewReader(logger, sink, buffer.DefaultBufferSize)
 
-		// First message should be ErrorResponse
 		msgType, _, err := reader.ReadTypedMsg()
 		assert.NoError(t, err)
 		assert.Equal(t, types.ServerMessage(msgType), types.ServerErrorResponse)
 
-		// Second message should be Ready
 		msgType, _, err = reader.ReadTypedMsg()
 		assert.NoError(t, err)
 		assert.Equal(t, types.ServerMessage(msgType), types.ServerReady)
 	})
 
-	t.Run("auth failure skips ready for query", func(t *testing.T) {
+	t.Run("extended query error sets discard flag without ready for query", func(t *testing.T) {
+		logger := slogt.New(t)
 		sink := bytes.NewBuffer([]byte{})
-		writer := buffer.NewWriter(slogt.New(t), sink)
+		writer := buffer.NewWriter(logger, sink)
 
-		// Authentication error should NOT include ready for query message
-		err := ErrorCode(writer, psqlerr.WithCode(errors.New("invalid username/password"), codes.InvalidPassword))
+		session := &Session{
+			Server:          &Server{logger: logger},
+			Statements:      &DefaultStatementCache{},
+			Portals:         &DefaultPortalCache{},
+			inExtendedQuery: true,
+		}
+
+		err := session.WriteError(writer, psqlerr.WithCode(errors.New("some error"), codes.Syntax))
 		assert.NoError(t, err)
+		assert.True(t, session.discardUntilSync)
 
-		// Check that we only have ErrorResponse, no Ready message
-		reader := buffer.NewReader(slogt.New(t), sink, buffer.DefaultBufferSize)
+		reader := buffer.NewReader(logger, sink, buffer.DefaultBufferSize)
 
-		// First message should be ErrorResponse
 		msgType, _, err := reader.ReadTypedMsg()
 		assert.NoError(t, err)
 		assert.Equal(t, types.ServerMessage(msgType), types.ServerErrorResponse)
 
-		// There should be no more messages
+		// No ReadyForQuery in extended query mode
 		_, _, err = reader.ReadTypedMsg()
-		assert.Error(t, err) // Should get EOF or similar
+		assert.Error(t, err)
 	})
+
+	t.Run("fatal error skips ready for query", func(t *testing.T) {
+		logger := slogt.New(t)
+		sink := bytes.NewBuffer([]byte{})
+		writer := buffer.NewWriter(logger, sink)
+
+		session := &Session{
+			Server:     &Server{logger: logger},
+			Statements: &DefaultStatementCache{},
+			Portals:    &DefaultPortalCache{},
+		}
+
+		err := session.WriteError(writer, psqlerr.WithCode(errors.New("invalid username/password"), codes.InvalidPassword))
+		assert.NoError(t, err)
+
+		reader := buffer.NewReader(logger, sink, buffer.DefaultBufferSize)
+
+		msgType, _, err := reader.ReadTypedMsg()
+		assert.NoError(t, err)
+		assert.Equal(t, types.ServerMessage(msgType), types.ServerErrorResponse)
+
+		_, _, err = reader.ReadTypedMsg()
+		assert.Error(t, err)
+	})
+}
+
+// TestExtendedQueryParseErrorRecovery verifies that a non-fatal error during
+// the extended query protocol doesn't desynchronize the connection.
+func TestExtendedQueryParseErrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		if query == "SELECT error" {
+			return nil, psqlerr.WithCode(errors.New("test error"), codes.Syntax)
+		}
+
+		stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		})
+		return Prepared(stmt), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connstr := fmt.Sprintf("postgres://%s:%d?default_query_exec_mode=cache_statement", address.IP, address.Port)
+	conn, err := pgx.Connect(ctx, connstr)
+	require.NoError(t, err)
+
+	// First query: triggers a non-fatal error
+	rows, _ := conn.Query(ctx, "SELECT error")
+	rows.Close()
+	assert.Error(t, rows.Err())
+
+	// Second query on the same connection must succeed
+	rows, err = conn.Query(ctx, "SELECT 1;")
+	require.NoError(t, err)
+	rows.Close()
+	assert.NoError(t, rows.Err())
+
+	err = conn.Close(ctx)
+	assert.NoError(t, err)
+}
+
+// TestExtendedQueryExecuteErrorRecovery verifies that an error during Execute
+// doesn't desynchronize the connection.
+func TestExtendedQueryExecuteErrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	handler := func(ctx context.Context, query string) (PreparedStatements, error) {
+		columns := Columns{{Name: "result", Oid: 25}} // text
+
+		if query == "SELECT error" {
+			stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+				return psqlerr.WithCode(errors.New("execution failed"), codes.DataException)
+			}, WithColumns(columns))
+			return Prepared(stmt), nil
+		}
+
+		stmt := NewStatement(func(ctx context.Context, writer DataWriter, parameters []Parameter) error {
+			return writer.Complete("OK")
+		}, WithColumns(columns))
+		return Prepared(stmt), nil
+	}
+
+	server, err := NewServer(handler, Logger(slogt.New(t)))
+	require.NoError(t, err)
+
+	address := TListenAndServe(t, server)
+
+	ctx := context.Background()
+	connstr := fmt.Sprintf("postgres://%s:%d?default_query_exec_mode=cache_statement", address.IP, address.Port)
+	conn, err := pgx.Connect(ctx, connstr)
+	require.NoError(t, err)
+
+	// First query: parses successfully but fails during Execute
+	rows, _ := conn.Query(ctx, "SELECT error")
+	rows.Close()
+	assert.Error(t, rows.Err())
+
+	// Second query must succeed
+	rows, err = conn.Query(ctx, "SELECT 1;")
+	require.NoError(t, err)
+	rows.Close()
+	assert.NoError(t, rows.Err())
+
+	err = conn.Close(ctx)
+	assert.NoError(t, err)
 }

--- a/pkg/mock/buffer.go
+++ b/pkg/mock/buffer.go
@@ -122,6 +122,29 @@ func NewDescribeReader(t *testing.T, logger *slog.Logger, describeType types.Des
 	return reader
 }
 
+// NewCloseReader creates a buffer.Reader containing a Close message ready to be processed.
+// closeType should be 'S' for statement or 'P' for portal.
+func NewCloseReader(t *testing.T, logger *slog.Logger, closeType byte, name string) *buffer.Reader {
+	t.Helper()
+
+	inputBuf := &bytes.Buffer{}
+	writer := NewWriter(t, inputBuf)
+	writer.Start(types.ClientClose)
+	writer.AddByte(closeType)
+	writer.AddString(name)
+	writer.AddNullTerminate()
+	if err := writer.End(); err != nil {
+		t.Fatalf("failed to write close message: %v", err)
+	}
+
+	reader := buffer.NewReader(logger, inputBuf, buffer.DefaultBufferSize)
+	if _, _, err := reader.ReadTypedMsg(); err != nil {
+		t.Fatalf("failed to read close message: %v", err)
+	}
+
+	return reader
+}
+
 // NewExecuteReader creates a buffer.Reader containing an Execute message ready to be processed.
 func NewExecuteReader(t *testing.T, logger *slog.Logger, portal string, limit int32) *buffer.Reader {
 	t.Helper()

--- a/response_queue.go
+++ b/response_queue.go
@@ -22,6 +22,8 @@ const (
 	// ResponseExecute represents an Execute with its complete result set
 	// (DataRows, CommandComplete)
 	ResponseExecute
+	// ResponseCloseComplete represents a CloseComplete ack
+	ResponseCloseComplete
 )
 
 // ResponseEvent represents an event in the response stream
@@ -70,6 +72,13 @@ func NewPortalDescribeEvent(columns Columns, formats []FormatCode) *ResponseEven
 		Kind:    ResponsePortalDescribe,
 		Columns: columns,
 		Formats: formats,
+	}
+}
+
+// NewCloseCompleteEvent creates a CloseComplete response event
+func NewCloseCompleteEvent() *ResponseEvent {
+	return &ResponseEvent{
+		Kind: ResponseCloseComplete,
 	}
 }
 

--- a/writer.go
+++ b/writer.go
@@ -68,9 +68,10 @@ var ErrRowLimitExceeded = pgerror.WithCode(errors.New("row limit exceeded"), cod
 // buffer. The returned writer should be handled with caution as it is not safe
 // for concurrent use. Concurrent access to the same data without proper
 // synchronization can result in unexpected behavior and data corruption.
-func NewDataWriter(ctx context.Context, columns Columns, formats []FormatCode, limit Limit, reader *buffer.Reader, writer *buffer.Writer) DataWriter {
+func NewDataWriter(ctx context.Context, session *Session, columns Columns, formats []FormatCode, limit Limit, reader *buffer.Reader, writer *buffer.Writer) DataWriter {
 	return &dataWriter{
 		ctx:     ctx,
+		session: session,
 		columns: columns,
 		formats: formats,
 		limit:   limit,
@@ -82,6 +83,7 @@ func NewDataWriter(ctx context.Context, columns Columns, formats []FormatCode, l
 // dataWriter is a implementation of the DataWriter interface.
 type dataWriter struct {
 	ctx     context.Context
+	session *Session
 	columns Columns
 	formats []FormatCode
 	limit   Limit
@@ -128,7 +130,7 @@ func (writer *dataWriter) CopyIn(format FormatCode) (*CopyReader, error) {
 		return nil, err
 	}
 
-	return NewCopyReader(writer.reader, writer.client, writer.columns), nil
+	return NewCopyReader(writer.session, writer.reader, writer.client, writer.columns), nil
 }
 
 func (writer *dataWriter) Empty() error {


### PR DESCRIPTION
https://github.com/shop/issues-materialization-platform/issues/544

Incorporates the fix from jeroenrinzema/psql-wire#131 to properly handle errors during extended query protocol processing.

Key changes:
- Session.WriteError() is protocol-aware: in extended query mode it writes only ErrorResponse and sets discardUntilSync (no ReadyForQuery). In simple query mode it writes ErrorResponse + ReadyForQuery as before.
- handleCommand() checks discardUntilSync flag and silently discards messages until Sync arrives, per the PostgreSQL protocol spec.
- handleSync() resets discardUntilSync and sends the single ReadyForQuery.
- handleClose() properly reads the Close message body (type + name).
- ResponseCloseComplete event added for pipeline mode Close handling.
- WriteUnterminatedError() for contexts without a session (e.g. auth).
- All ErrorCode() calls replaced with session-aware WriteError().
- Fixes double-ReadyForQuery bug in processResponseQueue and writeQueuedResponse that caused pipeline protocol desync.

This fixes three production errors:
1. 'server sent data (D message) without prior row description (T message)'
2. 'unexpected pg_result status: 1 - error_message: '
3. 'cannot exit pipeline mode while busy'